### PR TITLE
Replacing deprecated Fixnum with Integer

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,1 +1,0 @@
-vector_sse/

--- a/lib/vector_sse.rb
+++ b/lib/vector_sse.rb
@@ -138,7 +138,7 @@ module VectorSSE
 
          scalar_mul = false
 
-         if [ Fixnum, Float ].include? other.class
+         if [ Integer, Float ].include? other.class
 
             scalar_mul = true
             scalar_value = other
@@ -195,7 +195,7 @@ module VectorSSE
 
       def +( other )
 
-         if [ Fixnum, Float ].include? other.class
+         if [ Integer, Float ].include? other.class
 
             scalar_value = other
             other = Mat.new( @type, @rows, @cols )
@@ -211,7 +211,7 @@ module VectorSSE
          else
 
             raise ArgumentError.new(
-               "expect argument of type #{self.class}, Fixnum, or Float for argument 0" )
+               "expect argument of type #{self.class}, Integer, or Float for argument 0" )
 
          end
 
@@ -233,7 +233,7 @@ module VectorSSE
 
       def -( other )
 
-         if [ Fixnum, Float ].include? other.class
+         if [ Integer, Float ].include? other.class
 
             scalar_value = other
             other = Mat.new( @type, @rows, @cols )
@@ -249,7 +249,7 @@ module VectorSSE
          else
 
             raise ArgumentError.new(
-               "expect argument of type #{self.class}, Fixnum, or Float for argument 0" )
+               "expect argument of type #{self.class}, Integer, or Float for argument 0" )
 
          end
 
@@ -309,8 +309,8 @@ module VectorSSE
 
       def valid_data_type( value )
 
-         unless [ Fixnum, Float ].include? value.class
-            raise ArgumentError.new( "expected argument of type Fixnum or Float" )
+         unless [ Integer, Float ].include? value.class
+            raise ArgumentError.new( "expected argument of type Integer or Float" )
          end
 
       end
@@ -336,27 +336,27 @@ module VectorSSE
       end
 
       def <<( value )
-         unless [ Fixnum, Float ].include? value.class
+         unless [ Integer, Float ].include? value.class
             raise ArgumentError.new(
-               "expected argument of type Fixnum or Float for argument 0" )
+               "expected argument of type Integer or Float for argument 0" )
          end
          super( value )
       end
 
       def insert( index, *values )
          values.each_with_index do |value,arg_index|
-            unless [ Fixnum, Float ].include? value.class
+            unless [ Integer, Float ].include? value.class
                raise ArgumentError.new(
-                  "expected argument of type Fixnum or Float for argument #{arg_index}" )
+                  "expected argument of type Integer or Float for argument #{arg_index}" )
             end
          end
          super( index, values )
       end
 
       def []=( index, value )
-         unless [ Fixnum, Float ].include? value.class
+         unless [ Integer, Float ].include? value.class
             raise ArgumentError.new(
-               "expected argument of type Fixnum or Float for argument 1" )
+               "expected argument of type Integer or Float for argument 1" )
          end
          super( index, value )
       end
@@ -367,14 +367,14 @@ module VectorSSE
       #
       def +( other )
 
-         if [ Fixnum, Float ].include? other.class
+         if [ Integer, Float ].include? other.class
 
             other = ::Array.new( self.length, other )
 
          elsif other.class != self.class
 
             raise ArgumentError.new(
-               "expect argument of type #{self.class}, Fixnum, or Float for argument 0" )
+               "expect argument of type #{self.class}, Integer, or Float for argument 0" )
 
          end
 
@@ -400,11 +400,11 @@ module VectorSSE
       #
       def -( other )
 
-         if [ Fixnum, Float ].include? other.class
+         if [ Integer, Float ].include? other.class
             other = ::Array.new( self.length, other )
          elsif other.class != self.class
             raise ArgumentError.new(
-               "expected argument of type #{self.class}, Fixnum, or Float for argument 0" )
+               "expected argument of type #{self.class}, Integer, or Float for argument 0" )
          end
 
          result = self.class.new( @type )
@@ -444,9 +444,9 @@ module VectorSSE
 
       def *( other )
 
-         unless [ Fixnum, Float ].include? other.class
+         unless [ Integer, Float ].include? other.class
 
-            raise ArgumentError.new( "expected argument of type Float or Fixnum for argument 0" )
+            raise ArgumentError.new( "expected argument of type Float or Integer for argument 0" )
 
          end
 

--- a/lib/vector_sse.rb
+++ b/lib/vector_sse.rb
@@ -36,8 +36,6 @@ require File.join( bin_root, 'vector_sse.so' )
 
 module VectorSSE
 
-   VERSION = "0.0.3"
-
    module Type
       S32 = 0
       S64 = 1

--- a/lib/vector_sse/version.rb
+++ b/lib/vector_sse/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module VectorSSE
+  VERSION = "0.0.4".freeze
+end

--- a/vector_sse.gemspec
+++ b/vector_sse.gemspec
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
+require "vector_sse/version"
 
 Gem::Specification.new do |s|
    s.name        = 'vector_sse'
-   s.version     = VectorSSE::VERSION
+   s.version     = VectorSSE::VERSION.dup
    s.date        = Time.now.to_date.strftime('%Y-%m-%d')
    s.summary     = "SIMD accelerated vector and matrix operations"
    s.description = "VectorSse employs x86 Streaming SIMD Extensions (SSE), v3 or greater, to accelerate basic vector and matrix computations in Ruby."

--- a/vector_sse.gemspec
+++ b/vector_sse.gemspec
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-require_relative 'lib/vector_sse'
 
 Gem::Specification.new do |s|
    s.name        = 'vector_sse'

--- a/vector_sse.gemspec
+++ b/vector_sse.gemspec
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+
+$:.push File.expand_path("../lib", __FILE__)
 require "vector_sse/version"
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
FixNum has been [deprecated as of Ruby 2.4](https://bigbinary.com/blog/ruby-2-4-unifies-fixnum-and-bignum-into-integer):

This PR replaces `Fixnum` with the `Integer` class, per [the recommendation](https://bugs.ruby-lang.org/issues/12005).

It also updates the `gemspec` so that it can be installed directly from GitHub